### PR TITLE
Tell user manual extraction is not supported

### DIFF
--- a/analysis/analysis_deeplabcut.py
+++ b/analysis/analysis_deeplabcut.py
@@ -272,7 +272,7 @@ Actions are: create, template, edit, extract, label, train, evaluate, run, video
         import tkinter as tk
         from tkinter.filedialog import askopenfilename, asksaveasfilename
         import tkinter.messagebox as messagebox
-s
+        
         def open_file():
             """Open a file for editing."""
             filepath = configpath
@@ -355,6 +355,7 @@ s
         import os
         from pathlib import Path
         configpath = self.get_project_folder()
+        project_folder = configpath.replace('/config.yaml', '')
         if not os.path.exists(configpath):
             print('No project found, create it first.')
         import deeplabcut as dlc
@@ -367,10 +368,9 @@ s
             print(future_new_video_path)
             if future_new_video_path.is_file():
                 print('Video has already been added to the project. Proceeding with extraction.')
-                if self.extract_params['extract_mode'] == 'manual':
-                    from deeplabcut.gui.widgets import launch_napari
-                    labeled_data_folder = glob(pjoin(project_folder, 'labeled-data', '*'+self.session[0]+'*'+self.video_filter+'*'))[0]
-                    launch_napari([labeled_data_folder, configpath])
+                if self.extractparams['mode'] == 'manual':
+                    from deeplabcut.generate_training_dataset.frame_extraction import extract_frames
+                    extract_frames(config=configpath, mode=self.extractparams['mode'])
                     napari.run()
                 else:
                     dlc.extract_frames(configpath,
@@ -382,10 +382,10 @@ s
                 new_video = self.get_video_path()
                 dlc.add_new_videos(configpath, new_video, copy_videos=False, coords=None, extract_frames=True)
         else:
-            if self.extract_params['extract_mode'] == 'manual':
+            if self.extractparams['mode'] == 'manual':
                 from deeplabcut.gui.widgets import launch_napari
                 labeled_data_folder = glob(pjoin(project_folder, 'labeled-data', '*'+self.session[0]+'*'+self.video_filter+'*'))[0]
-                launch_napari([labeled_data_folder, configpath])
+                launch_napari(self.get_video_path()[0])
                 napari.run()
             else:
                 dlc.extract_frames(configpath,

--- a/analysis/analysis_deeplabcut.py
+++ b/analysis/analysis_deeplabcut.py
@@ -272,7 +272,7 @@ Actions are: create, template, edit, extract, label, train, evaluate, run, video
         import tkinter as tk
         from tkinter.filedialog import askopenfilename, asksaveasfilename
         import tkinter.messagebox as messagebox
-
+s
         def open_file():
             """Open a file for editing."""
             filepath = configpath
@@ -367,8 +367,14 @@ Actions are: create, template, edit, extract, label, train, evaluate, run, video
             print(future_new_video_path)
             if future_new_video_path.is_file():
                 print('Video has already been added to the project. Proceeding with extraction.')
-                dlc.extract_frames(configpath, **self.extractparams)
-                napari.run()
+                if self.extract_params['extract_mode'] == 'manual':
+                    from deeplabcut.gui.widgets import launch_napari
+                    labeled_data_folder = glob(pjoin(project_folder, 'labeled-data', '*'+self.session[0]+'*'+self.video_filter+'*'))[0]
+                    launch_napari([labeled_data_folder, configpath])
+                    napari.run()
+                else:
+                    dlc.extract_frames(configpath,
+                                   **self.extractparams)
                 self.overwrite = True
             else:
                 print('Video has not been added to the project.\
@@ -376,12 +382,15 @@ Actions are: create, template, edit, extract, label, train, evaluate, run, video
                 new_video = self.get_video_path()
                 dlc.add_new_videos(configpath, new_video, copy_videos=False, coords=None, extract_frames=True)
         else:
-            from deeplabcut.gui.widgets import launch_napari
-            labeled_data_folder = glob(pjoin(project_folder, 'labeled-data', '*'+self.session[0]+'*'+self.video_filter+'*'))[0]
-            launch_napari([labeled_data_folder, configpath])
-            dlc.extract_frames(configpath,
-                           **self.extractparams)
-            napari.run()
+            if self.extract_params['extract_mode'] == 'manual':
+                from deeplabcut.gui.widgets import launch_napari
+                labeled_data_folder = glob(pjoin(project_folder, 'labeled-data', '*'+self.session[0]+'*'+self.video_filter+'*'))[0]
+                launch_napari([labeled_data_folder, configpath])
+                napari.run()
+            else:
+                dlc.extract_frames(configpath,
+                                   **self.extractparams)
+            
             self.overwrite = True
 
     def _label_frames(self):

--- a/analysis/analysis_deeplabcut.py
+++ b/analysis/analysis_deeplabcut.py
@@ -272,7 +272,7 @@ Actions are: create, template, edit, extract, label, train, evaluate, run, video
         import tkinter as tk
         from tkinter.filedialog import askopenfilename, asksaveasfilename
         import tkinter.messagebox as messagebox
-        
+
         def open_file():
             """Open a file for editing."""
             filepath = configpath
@@ -355,11 +355,7 @@ Actions are: create, template, edit, extract, label, train, evaluate, run, video
         import os
         from pathlib import Path
         configpath = self.get_project_folder()
-<<<<<<< Updated upstream
-        project_folder = configpath.replace('/config.yaml', '')
-=======
         # project_folder = configpath.replace('/config.yaml', '')
->>>>>>> Stashed changes
         if not os.path.exists(configpath):
             print('No project found, create it first.')
         import deeplabcut as dlc
@@ -373,21 +369,11 @@ Actions are: create, template, edit, extract, label, train, evaluate, run, video
             print(future_new_video_path)
             if future_new_video_path.is_file():
                 print('Video has already been added to the project. Proceeding with extraction.')
-<<<<<<< Updated upstream
-                if self.extractparams['mode'] == 'manual':
-                    from deeplabcut.generate_training_dataset.frame_extraction import extract_frames
-                    extract_frames(config=configpath, mode=self.extractparams['mode'])
-                    napari.run()
-                else:
-                    dlc.extract_frames(configpath,
-                                   **self.extractparams)
-=======
                 if self.extractparams['mode'] == 'automatic':
                     dlc.extract_frames(configpath, **self.extractparams)
                     napari.run()
                 elif self.extractparams['mode'] == 'manual':
                     print('Manual labeling is currently not supported in labdata-tools DLC. Please launch the DLC GUI for this step.')
->>>>>>> Stashed changes
                 self.overwrite = True
             else:
                 print('Video has not been added to the project.\
@@ -403,17 +389,6 @@ Actions are: create, template, edit, extract, label, train, evaluate, run, video
                     print('Manual labeling is currently not supported in labdata-tools DLC. Please launch the DLC GUI for this step.')
                 self.overwrite = True
         else:
-<<<<<<< Updated upstream
-            if self.extractparams['mode'] == 'manual':
-                from deeplabcut.gui.widgets import launch_napari
-                labeled_data_folder = glob(pjoin(project_folder, 'labeled-data', '*'+self.session[0]+'*'+self.video_filter+'*'))[0]
-                launch_napari(self.get_video_path()[0])
-                napari.run()
-            else:
-                dlc.extract_frames(configpath,
-                                   **self.extractparams)
-            
-=======
             print('Video has already been added to the project. Proceeding with extraction.')
             if self.extractparams['mode'] == 'automatic':
                 dlc.extract_frames(configpath,
@@ -430,7 +405,6 @@ Actions are: create, template, edit, extract, label, train, evaluate, run, video
                 # _ = launch_napari(files = self.get_video_path())
                 # napari.run()
                 print('Manual labeling is currently not supported in labdata DLC. Please launch the DLC GUI for this step.')
->>>>>>> Stashed changes
             self.overwrite = True
 
     def _label_frames(self):

--- a/analysis/analysis_deeplabcut.py
+++ b/analysis/analysis_deeplabcut.py
@@ -355,12 +355,17 @@ Actions are: create, template, edit, extract, label, train, evaluate, run, video
         import os
         from pathlib import Path
         configpath = self.get_project_folder()
+<<<<<<< Updated upstream
         project_folder = configpath.replace('/config.yaml', '')
+=======
+        # project_folder = configpath.replace('/config.yaml', '')
+>>>>>>> Stashed changes
         if not os.path.exists(configpath):
             print('No project found, create it first.')
         import deeplabcut as dlc
         import napari
-        if self.session is not self.labeling_session:
+        if self.session[0] is not self.labeling_session:
+            print('Checking if new labeling session video has already been added to the project...')
             future_new_video = Path(self.get_video_path()[0])
             head_tail = os.path.split(future_new_video)
             project_videos_path = self.get_project_videos_path()
@@ -368,6 +373,7 @@ Actions are: create, template, edit, extract, label, train, evaluate, run, video
             print(future_new_video_path)
             if future_new_video_path.is_file():
                 print('Video has already been added to the project. Proceeding with extraction.')
+<<<<<<< Updated upstream
                 if self.extractparams['mode'] == 'manual':
                     from deeplabcut.generate_training_dataset.frame_extraction import extract_frames
                     extract_frames(config=configpath, mode=self.extractparams['mode'])
@@ -375,13 +381,29 @@ Actions are: create, template, edit, extract, label, train, evaluate, run, video
                 else:
                     dlc.extract_frames(configpath,
                                    **self.extractparams)
+=======
+                if self.extractparams['mode'] == 'automatic':
+                    dlc.extract_frames(configpath, **self.extractparams)
+                    napari.run()
+                elif self.extractparams['mode'] == 'manual':
+                    print('Manual labeling is currently not supported in labdata-tools DLC. Please launch the DLC GUI for this step.')
+>>>>>>> Stashed changes
                 self.overwrite = True
             else:
                 print('Video has not been added to the project.\
                       Adding it to project now.')
                 new_video = self.get_video_path()
                 dlc.add_new_videos(configpath, new_video, copy_videos=False, coords=None, extract_frames=True)
+
+                print('Video has now been added. Proceeding with extraction.')
+                if self.extractparams['mode'] == 'automatic':
+                    dlc.extract_frames(configpath, **self.extractparams)
+                    napari.run()
+                elif self.extractparams['mode'] == 'manual':
+                    print('Manual labeling is currently not supported in labdata-tools DLC. Please launch the DLC GUI for this step.')
+                self.overwrite = True
         else:
+<<<<<<< Updated upstream
             if self.extractparams['mode'] == 'manual':
                 from deeplabcut.gui.widgets import launch_napari
                 labeled_data_folder = glob(pjoin(project_folder, 'labeled-data', '*'+self.session[0]+'*'+self.video_filter+'*'))[0]
@@ -391,6 +413,24 @@ Actions are: create, template, edit, extract, label, train, evaluate, run, video
                 dlc.extract_frames(configpath,
                                    **self.extractparams)
             
+=======
+            print('Video has already been added to the project. Proceeding with extraction.')
+            if self.extractparams['mode'] == 'automatic':
+                dlc.extract_frames(configpath,
+                            **self.extractparams)
+            elif self.extractparams['mode'] == 'manual':
+                """
+                TODO:
+                - on top of loading the video extremely slow, DLC also expects the labeled-data dir to be up one folder from where the video is
+                - this is a problem because the project lives in a separate folder from the video (symlink to chipmunk folder vs. real video in videos folder)
+                - one solution would be to modify the extract frames function in napari-deeplabcut to work with our labdata DLC structure
+                - but that would potentially break normal GUI function. for now, let's tell the user they can't do manual extraction through this CLI.
+                """
+                # from deeplabcut.gui.widgets import launch_napari
+                # _ = launch_napari(files = self.get_video_path())
+                # napari.run()
+                print('Manual labeling is currently not supported in labdata DLC. Please launch the DLC GUI for this step.')
+>>>>>>> Stashed changes
             self.overwrite = True
 
     def _label_frames(self):


### PR DESCRIPTION
Manual extraction of video frames for DLC labeling using labdata-tools isn't currently functional. The issue arises because when the user clicks on a frame to extract inside of `napari`, the built-in `napari-deeplabcut` function for writing that frame wants to write it in the `labeled-data` directory that is upstream of the `videos` directory inside of the project folder. 

The problem here, though, is that the video file in `videos` is usually a symlink to a different folder where the actual video lives . Specifically, it wants the video to live in `subject/session/dlc_labeling/videos` but it really lives in `subject/session/task` instead. 

Since fixing this would require either changing the way labdata-tools works regarding DLC data storage or modifying a built-in function in `napari-deeplabcut`, I think it's best to just tell the user to load up the normal GUI through `python -m deeplabcut` and extract the frames manually there since that _does_ work and the operation requires a GUI anyways and doesn't necessarily benefit a lot from being performed inside of labdata-tools.